### PR TITLE
BSD `env` and GNU `env` differ in whether they need -S

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node --experimental-vm-modules
+#!/usr/bin/env -S node --experimental-vm-modules
 
 /*
  * Copyright 2022 Andrew Aylett


### PR DESCRIPTION
MacOS seems not to, GitHub Action Runners running Ubuntu do.

Signed-off-by: Andrew Aylett <andrew@aylett.co.uk>